### PR TITLE
Admin Backend: erase only route-related tables on clean load

### DIFF
--- a/Python/apps/backend_admin/service/db_management/db_dumper.py
+++ b/Python/apps/backend_admin/service/db_management/db_dumper.py
@@ -1,11 +1,13 @@
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+TABLES = {"drop", "service_prices", "prices", "routes", "companies", "containers", "points", "services"}
 
-async def create_db_dump(session: AsyncSession, structure: bool):
+
+async def create_db_dump(session: AsyncSession, structure: bool, all_tables: bool = False):
     yield "SET FOREIGN_KEY_CHECKS = 0;\n\n"
 
-    tables_descriptor = (await session.execute(text("SHOW TABLES"))).scalars()
+    tables_descriptor = (await session.execute(text("SHOW TABLES"))).scalars() if all_tables else TABLES
 
     for table in tables_descriptor:
         if table == "alembic_version":

--- a/Python/apps/backend_admin/service/db_management/db_eraser.py
+++ b/Python/apps/backend_admin/service/db_management/db_eraser.py
@@ -1,14 +1,13 @@
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+TABLES = {"drop", "service_prices", "prices", "routes", "companies", "containers", "points", "services"}
+
 
 async def clear_database_data(session: AsyncSession):
     await session.execute(text("SET FOREIGN_KEY_CHECKS = 0"))
 
-    tables_descriptor = (await session.execute(text("SHOW TABLES"))).scalars()
-
-    for table in tables_descriptor:
-        if table != "alembic_version":
-            await session.execute(text(f"DELETE FROM `{table}`"))
+    for table in TABLES:
+        await session.execute(text(f"DELETE FROM `{table}`"))
 
     await session.execute(text("SET FOREIGN_KEY_CHECKS = 1"))


### PR DESCRIPTION
Fixes #78

Affected endpoints: `DELETE /db/data`, `GET /db/data`